### PR TITLE
Reproduction and fixes to the issue #6

### DIFF
--- a/carbs/utils.py
+++ b/carbs/utils.py
@@ -566,6 +566,12 @@ def get_pareto_groups_conservative(
         for group in grouped_observations
         if observation_group_cost(group) <= min_pareto_cost
     ]
+    # When there happens to be no observations below the min threshold, inspect observations' cost individually
+    if len(observations_below_min_threshold) == 0:
+        observations_below_min_threshold = [
+            tuple(x) for group in grouped_observations for x in group if x.cost <= min_pareto_cost
+        ]
+
     resampled_observations_below_min_threshold = [
         group for group in observations_below_min_threshold if len(group) > 1
     ]

--- a/carbs/utils.py
+++ b/carbs/utils.py
@@ -568,8 +568,11 @@ def get_pareto_groups_conservative(
     ]
     # When there happens to be no observations below the min threshold, inspect observations' cost individually
     if len(observations_below_min_threshold) == 0:
+        logger.warning(
+            "There is no grouped obs below min_pareto_cost. So inspect observations' cost individually."
+        )
         observations_below_min_threshold = [
-            tuple(x) for group in grouped_observations for x in group if x.cost <= min_pareto_cost
+            (x,) for group in grouped_observations for x in group if x.cost <= min_pareto_cost
         ]
 
     resampled_observations_below_min_threshold = [


### PR DESCRIPTION
Hello, thank you and kudos for the awesome library and paper.

The code below can reproduce issue #6 , which seems to stem from two causes:

```python
def test_no_repeat_random_suggestions(carbs_instance: CARBS) -> None:
    num_to_suggest = 10
    for i in range(num_to_suggest):
        # Simulate a case where the same seed is kept set elsewhere
        carbs_instance._set_seed(1)
        suggestion = carbs_instance._get_random_suggestion()
        observation = ObservationInParam(input=suggestion.suggestion, output=i, cost=i + 1)
        carbs_instance.observe(observation)
        print(suggestion.suggestion)
```

In my work (and Joseph's pufferlib), we run a seeding function at each training, which also seems to affect CARBS' random sampling. As a result, I got many (like 9) repeated samples out of 10 random samples. The same suggestion is then fed into the observations with different costs, and as Joseph said, "there can be no groups for which the mean is less than the quantile."

My fix addresses both issues:
* Mask out the param candidates that are in the success and failure observations in `_get_mask_for_invalid_points_in_basic()`, which is NOT used for resampling.
* Inspect observations individually, instead of in groups, to create `observations_below_min_threshold` when the group-based result is empty.

Please let me know if you need anything else.